### PR TITLE
Fixes comment: https://github.com/kiegroup/kie-tools/pull/1458#discus…

### DIFF
--- a/packages/serverless-logic-web-tools/src/editor/EditorPage.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/EditorPage.tsx
@@ -92,6 +92,7 @@ export function EditorPage(props: Props) {
   const [embeddedEditorFile, setEmbeddedEditorFile] = useState<EmbeddedEditorFile>();
   const isEditorReady = useMemo(() => editor?.isReady, [editor]);
   const [isReady, setReady] = useState(false);
+  const [isServiceRegistryReady, setServiceRegistryReady] = useState(false);
   const swfFeatureToggle = useSwfFeatureToggle(editor);
 
   const queryParams = useQueryParams();
@@ -280,8 +281,9 @@ export function EditorPage(props: Props) {
   // SWF-specific code should be isolated when having more capabilities for other editors.
 
   useEffect(() => {
+    setServiceRegistryReady(false);
     if (isSwf && isReady) {
-      settingsDispatch.serviceRegistry.catalogStore.refresh();
+      settingsDispatch.serviceRegistry.catalogStore.refresh().then(() => setServiceRegistryReady(true));
     }
   }, [isSwf, isReady, settingsDispatch.serviceRegistry.catalogStore]);
 
@@ -386,7 +388,14 @@ export function EditorPage(props: Props) {
         editorPageDock?.setNotifications(i18n.terms.validation, "", diagnostics);
       })
       .catch((e) => console.error(e));
-  }, [workspaceFilePromise.data, editor, swfLanguageService, editorPageDock, i18n.terms.validation]);
+  }, [
+    workspaceFilePromise.data,
+    editor,
+    swfLanguageService,
+    editorPageDock,
+    i18n.terms.validation,
+    isServiceRegistryReady,
+  ]);
 
   const swfEditorChannelApi = useMemo(
     () =>


### PR DESCRIPTION
Fixes: https://github.com/kiegroup/kie-tools/pull/1458#discussion_r1108315623

@caponetto, please review this PR

If I refresh the editor page with F5, `globalServices`and `relativeServices`, in `getDiagnostics()`, are empty and "Problems 0" is shown in the status bar.
Clicking on "Problems 0" button, the errors are shown and the count is 11.

[KOGITO-8335-problems-count.webm](https://user-images.githubusercontent.com/17780574/219350426-23c4e0fa-dd59-40cb-96a8-beb17ce6a7fc.webm)

